### PR TITLE
Move from `main` triggers to `master` triggers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    target-branch: main
+    target-branch: master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Shard CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy documentation
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
Just pushing in a quick update for GitHub workflow triggers.