### PR TITLE
Adds Event object and Webhook class

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ But follow [https://stripe.com/docs/billing/subscriptions/set-up-subscription](h
 
 - [ ] Dispute evidence
 
-- [ ] Event
+- [x] Event
 
 - [ ] File
 

--- a/spec/stripe/methods/event_spec.cr
+++ b/spec/stripe/methods/event_spec.cr
@@ -1,0 +1,8 @@
+require "../../spec_helper"
+
+describe Stripe::Event do
+  it "constructs event" do
+    event = Stripe::Event.from_json(File.read("spec/support/event.json"))
+    event.data.object.id.should eq("prod_JTgbc7dgwVuto4")
+  end
+end

--- a/spec/stripe/methods/event_spec.cr
+++ b/spec/stripe/methods/event_spec.cr
@@ -1,8 +1,0 @@
-require "../../spec_helper"
-
-describe Stripe::Event do
-  it "constructs event" do
-    event = Stripe::Event.from_json(File.read("spec/support/event.json"))
-    event.data.object.id.should eq("prod_JTgbc7dgwVuto4")
-  end
-end

--- a/spec/stripe/methods/webhook_spec.cr
+++ b/spec/stripe/methods/webhook_spec.cr
@@ -16,7 +16,8 @@ describe Stripe::Webhook do
       scheme: "v1"
     )
     event = Stripe::Webhook.construct_event(payload, header, secret)
-    event.type.should eq("product.updated")
+
+    {event.type, event.data.object.is_a?(Stripe::Product), event.data.previous_attributes}.should eq({"product.updated", true, {"metadata" => {"tier" => nil}, "updated" => 1620930329}})
   end
   it "Raises on wrong secret" do
     timestamp = Time.utc

--- a/spec/stripe/methods/webhook_spec.cr
+++ b/spec/stripe/methods/webhook_spec.cr
@@ -2,19 +2,19 @@ require "../../spec_helper"
 
 describe Stripe::Webhook do
   it "construct_event" do
-    timestamp : Time.utc
+    timestamp = Time.utc
     payload = File.read("spec/support/event.json")
     secret = "secret"
     signature = Stripe::Webhook::Signature.compute_signature(
-        timestamp,
-        payload,
-        secret
-      )
-    header =  Stripe::Webhook::Signature.generate_header(
-        timestamp,
-        signature,
-        scheme: "v1"
-      )
+      timestamp,
+      payload,
+      secret
+    )
+    header = Stripe::Webhook::Signature.generate_header(
+      timestamp,
+      signature,
+      scheme: "v1"
+    )
     event = Stripe::Webhook.construct_event(payload, header, secret)
     event.data.object.id.should eq("prod_JTgbc7dgwVuto4")
   end

--- a/spec/stripe/methods/webhook_spec.cr
+++ b/spec/stripe/methods/webhook_spec.cr
@@ -1,0 +1,21 @@
+require "../../spec_helper"
+
+describe Stripe::Webhook do
+  it "construct_event" do
+    timestamp : Time.utc
+    payload = File.read("spec/support/event.json")
+    secret = "secret"
+    signature = Stripe::Webhook::Signature.compute_signature(
+        timestamp,
+        payload,
+        secret
+      )
+    header =  Stripe::Webhook::Signature.generate_header(
+        timestamp,
+        signature,
+        scheme: "v1"
+      )
+    event = Stripe::Webhook.construct_event(payload, header, secret)
+    event.data.object.id.should eq("prod_JTgbc7dgwVuto4")
+  end
+end

--- a/spec/stripe/methods/webhook_spec.cr
+++ b/spec/stripe/methods/webhook_spec.cr
@@ -18,4 +18,40 @@ describe Stripe::Webhook do
     event = Stripe::Webhook.construct_event(payload, header, secret)
     event.type.should eq("product.updated")
   end
+  it "Raises on wrong secret" do
+    timestamp = Time.utc
+    payload = File.read("spec/support/event.json")
+    secret = "secret"
+    signature = Stripe::Webhook::Signature.compute_signature(
+      timestamp,
+      payload,
+      secret
+    )
+    header = Stripe::Webhook::Signature.generate_header(
+      timestamp,
+      signature,
+      scheme: "v1"
+    )
+    expect_raises(SignatureVerificationError) do
+      Stripe::Webhook.construct_event(payload, header, "wrong_secret")
+    end
+  end
+  it "Raises on old timestamp" do
+    timestamp = Time.utc - 500.seconds
+    payload = File.read("spec/support/event.json")
+    secret = "secret"
+    signature = Stripe::Webhook::Signature.compute_signature(
+      timestamp,
+      payload,
+      secret
+    )
+    header = Stripe::Webhook::Signature.generate_header(
+      timestamp,
+      signature,
+      scheme: "v1"
+    )
+    expect_raises(SignatureVerificationError) do
+      Stripe::Webhook.construct_event(payload, header, secret)
+    end
+  end
 end

--- a/spec/stripe/methods/webhook_spec.cr
+++ b/spec/stripe/methods/webhook_spec.cr
@@ -16,6 +16,6 @@ describe Stripe::Webhook do
       scheme: "v1"
     )
     event = Stripe::Webhook.construct_event(payload, header, secret)
-    event.data.object.id.should eq("prod_JTgbc7dgwVuto4")
+    event.type.should eq("product.updated")
   end
 end

--- a/spec/support/event.json
+++ b/spec/support/event.json
@@ -1,0 +1,44 @@
+{
+  "id": "evt_1IrCyVJN5FrkuvKhbHhhuS0B",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1621044691,
+  "data": {
+    "object": {
+      "id": "prod_JTgbc7dgwVuto4",
+      "object": "product",
+      "active": true,
+      "attributes": [],
+      "created": 1620930329,
+      "description": "Plan Premium test",
+      "images": [
+        "https://files.stripe.com/links/MDB8YWNjdF8xSXFpd0ZKTjVGcmt1dktofGZsX3Rlc3RfTWZsd3Rsa1ZJMHBLOEdzRlFLaDB5bElW00FhECO8uS"
+      ],
+      "livemode": false,
+      "metadata": {
+        "tier": "premium"
+      },
+      "name": "Plan Premium",
+      "package_dimensions": null,
+      "shippable": null,
+      "statement_descriptor": null,
+      "type": "service",
+      "unit_label": null,
+      "updated": 1621044691,
+      "url": null
+    },
+    "previous_attributes": {
+      "metadata": {
+        "tier": null
+      },
+      "updated": 1620930329
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 0,
+  "request": {
+    "id": "req_RXlkgjj2SWzNjM",
+    "idempotency_key": null
+  },
+  "type": "product.updated"
+}

--- a/src/stripe/methods/core/webhook/webhook.cr
+++ b/src/stripe/methods/core/webhook/webhook.cr
@@ -41,7 +41,7 @@ class Stripe::Webhook
     # Extracts the timestamp and the signature(s) with the desired scheme
     # from the header
     private def self.get_timestamp_and_signatures(header : String, scheme : String) : Tuple(Time, Array(String))
-      list_items = header.split(',').map { |i| i.split("=", 2) } # ameba:disable Style/VerboseBlock
+      list_items = header.split(',').map(&.split("=", 2))
       timestamp = (list_items.select { |i| i[0] == "t" }[0][1]).to_i
       signatures = list_items.select { |i| i[0] == scheme }.map { |i| i[1] }
       {Time.unix(timestamp), signatures}

--- a/src/stripe/methods/core/webhook/webhook.cr
+++ b/src/stripe/methods/core/webhook/webhook.cr
@@ -83,7 +83,7 @@ class Stripe::Webhook
         )
       end
 
-      if timestamp.to_unix.to_i < Time.utc.to_unix.to_i - tolerance
+      if tolerance && timestamp.to_unix.to_i < Time.utc.to_unix.to_i - tolerance
         raise SignatureVerificationError.new(
           "Timestamp outside the tolerance zone (#{timestamp})",
           header: header, param: payload

--- a/src/stripe/methods/core/webhook/webhook.cr
+++ b/src/stripe/methods/core/webhook/webhook.cr
@@ -1,0 +1,114 @@
+# Adapted from https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/webhook.rb
+
+module Stripe
+  module Webhook
+    DEFAULT_TOLERANCE = 300
+
+    # Initializes an Event object from a JSON payload.
+    #
+    # This may raise JSON::ParserError if the payload is not valid JSON, or
+    # SignatureVerificationError if the signature verification fails.
+    def self.construct_event(payload, sig_header, secret,
+                             tolerance = DEFAULT_TOLERANCE)
+      Signature.verify_header(payload, sig_header, secret, tolerance: tolerance)
+
+      Stripe::Event.from_json(payload)
+    end
+
+    module Signature
+      EXPECTED_SCHEME = "v1"
+
+      # Computes a webhook signature given a time (probably the current time),
+      # a payload, and a signing secret.
+      def self.compute_signature(timestamp, payload, secret)
+        raise ArgumentError, "timestamp should be an instance of Time" \
+          unless timestamp.is_a?(Time)
+        raise ArgumentError, "payload should be a string" \
+          unless payload.is_a?(String)
+        raise ArgumentError, "secret should be a string" \
+          unless secret.is_a?(String)
+
+        timestamped_payload = "#{timestamp.to_i}.#{payload}"
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), secret,
+                                timestamped_payload)
+      end
+
+      # Generates a value that would be added to a `Stripe-Signature` for a
+      # given webhook payload.
+      #
+      # Note that this isn't needed to verify webhooks in any way, and is
+      # mainly here for use in test cases (those that are both within this
+      # project and without).
+      def self.generate_header(timestamp, signature, scheme = EXPECTED_SCHEME)
+        raise ArgumentError, "timestamp should be an instance of Time" \
+          unless timestamp.is_a?(Time)
+        raise ArgumentError, "signature should be a string" \
+          unless signature.is_a?(String)
+        raise ArgumentError, "scheme should be a string" \
+          unless scheme.is_a?(String)
+
+        "t=#{timestamp.to_i},#{scheme}=#{signature}"
+      end
+
+      # Extracts the timestamp and the signature(s) with the desired scheme
+      # from the header
+      private def self.get_timestamp_and_signatures(header, scheme)
+        list_items = header.split(/,\s*/).map { |i| i.split("=", 2) }
+        timestamp = (list_items.select { |i| i[0] == "t" }[0][1]).to_i
+        signatures = list_items.select { |i| i[0] == scheme }.map { |i| i[1] }
+        [Time.at(timestamp), signatures]
+      end
+
+      # Verifies the signature header for a given payload.
+      #
+      # Raises a SignatureVerificationError in the following cases:
+      # - the header does not match the expected format
+      # - no signatures found with the expected scheme
+      # - no signatures matching the expected signature
+      # - a tolerance is provided and the timestamp is not within the
+      #   tolerance
+      #
+      # Returns true otherwise
+      def self.verify_header(payload, header, secret, tolerance = nil)
+        begin
+          timestamp, signatures =
+            get_timestamp_and_signatures(header, EXPECTED_SCHEME)
+
+        # TODO: Try to knock over this blanket rescue as it can unintentionally
+        # swallow many valid errors. Instead, try to validate an incoming
+        # header one piece at a time, and error with a known exception class if
+        # any part is found to be invalid. Rescue that class here.
+        rescue StandardError
+          raise SignatureVerificationError.new(
+            "Unable to extract timestamp and signatures from header",
+            header, http_body: payload
+          )
+        end
+
+        if signatures.empty?
+          raise SignatureVerificationError.new(
+            "No signatures found with expected scheme #{EXPECTED_SCHEME}",
+            header, http_body: payload
+          )
+        end
+
+        expected_sig = compute_signature(timestamp, payload, secret)
+        unless signatures.any? { |s| Util.secure_compare(expected_sig, s) }
+          raise SignatureVerificationError.new(
+            "No signatures found matching the expected signature for payload",
+            header, http_body: payload
+          )
+        end
+
+        if tolerance && timestamp < Time.now - tolerance
+          raise SignatureVerificationError.new(
+            "Timestamp outside the tolerance zone (#{Time.at(timestamp)})",
+            header, http_body: payload
+          )
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/src/stripe/methods/core/webhook/webhook.cr
+++ b/src/stripe/methods/core/webhook/webhook.cr
@@ -1,7 +1,6 @@
 # Adapted from https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/webhook.rb
 
-module Stripe
-  module Webhook
+  class Stripe::Webhook
     DEFAULT_TOLERANCE = 300
 
     # Initializes an Event object from a JSON payload.
@@ -111,4 +110,3 @@ module Stripe
       end
     end
   end
-end

--- a/src/stripe/methods/core/webhook/webhook.cr
+++ b/src/stripe/methods/core/webhook/webhook.cr
@@ -1,112 +1,106 @@
 # Adapted from https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/webhook.rb
 
-  class Stripe::Webhook
-    DEFAULT_TOLERANCE = 300
+require "crypto/subtle"
+require "openssl/hmac"
 
-    # Initializes an Event object from a JSON payload.
-    #
-    # This may raise JSON::ParserError if the payload is not valid JSON, or
-    # SignatureVerificationError if the signature verification fails.
-    def self.construct_event(payload, sig_header, secret,
-                             tolerance = DEFAULT_TOLERANCE)
-      Signature.verify_header(payload, sig_header, secret, tolerance: tolerance)
+class Stripe::Webhook
+  DEFAULT_TOLERANCE = 300
 
-      Stripe::Event.from_json(payload)
+  # Initializes an Event object from a JSON payload.
+  #
+  # This may raise JSON::SerializableError if the payload is not valid JSON, or
+  # SignatureVerificationError if the signature verification fails.
+  def self.construct_event(payload : String, sig_header : String, secret : String,
+                           tolerance : Int32? = DEFAULT_TOLERANCE)
+    Signature.verify_header(payload: payload, header: sig_header, secret: secret, tolerance: tolerance)
+
+    Stripe::Event.from_json(payload)
+  end
+
+  module Signature
+    EXPECTED_SCHEME = "v1"
+
+    # Computes a webhook signature given a time (probably the current time),
+    # a payload, and a signing secret.
+    def self.compute_signature(timestamp : Time, payload : String, secret : String) : String
+      timestamped_payload = "#{timestamp.to_unix.to_i}.#{payload}"
+      OpenSSL::HMAC.hexdigest(OpenSSL::Algorithm.new(:SHA256), secret,
+        timestamped_payload)
     end
 
-    module Signature
-      EXPECTED_SCHEME = "v1"
+    # Generates a value that would be added to a `Stripe-Signature` for a
+    # given webhook payload.
+    #
+    # Note that this isn't needed to verify webhooks in any way, and is
+    # mainly here for use in test cases (those that are both within this
+    # project and without).
+    def self.generate_header(timestamp : Time, signature : String, scheme : String = EXPECTED_SCHEME) : String
+      "t=#{timestamp.to_unix},#{scheme}=#{signature}"
+    end
 
-      # Computes a webhook signature given a time (probably the current time),
-      # a payload, and a signing secret.
-      def self.compute_signature(timestamp, payload, secret)
-        raise ArgumentError, "timestamp should be an instance of Time" \
-          unless timestamp.is_a?(Time)
-        raise ArgumentError, "payload should be a string" \
-          unless payload.is_a?(String)
-        raise ArgumentError, "secret should be a string" \
-          unless secret.is_a?(String)
+    # Extracts the timestamp and the signature(s) with the desired scheme
+    # from the header
+    private def self.get_timestamp_and_signatures(header : String, scheme : String) : Tuple(Time, Array(String))
+      list_items = header.split(',').map { |i| i.split("=", 2) } # ameba:disable Style/VerboseBlock
+      timestamp = (list_items.select { |i| i[0] == "t" }[0][1]).to_i
+      signatures = list_items.select { |i| i[0] == scheme }.map { |i| i[1] }
+      {Time.unix(timestamp), signatures}
+    end
 
-        timestamped_payload = "#{timestamp.to_i}.#{payload}"
-        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), secret,
-                                timestamped_payload)
+    # Verifies the signature header for a given payload.
+    #
+    # Raises a SignatureVerificationError in the following cases:
+    # - the header does not match the expected format
+    # - no signatures found with the expected scheme
+    # - no signatures matching the expected signature
+    # - a tolerance is provided and the timestamp is not within the
+    #   tolerance
+    #
+    # Returns true otherwise
+    def self.verify_header(payload : String, header : String, secret : String, tolerance : Int32? = nil) : Bool
+      begin
+        timestamp = get_timestamp_and_signatures(header, EXPECTED_SCHEME).first.as(Time)
+        signatures = get_timestamp_and_signatures(header, EXPECTED_SCHEME).last.as(Array(String))
+      rescue
+        raise SignatureVerificationError.new(
+          message: "Unable to extract timestamp and signatures from header",
+          header: header, param: payload
+        )
       end
 
-      # Generates a value that would be added to a `Stripe-Signature` for a
-      # given webhook payload.
-      #
-      # Note that this isn't needed to verify webhooks in any way, and is
-      # mainly here for use in test cases (those that are both within this
-      # project and without).
-      def self.generate_header(timestamp, signature, scheme = EXPECTED_SCHEME)
-        raise ArgumentError, "timestamp should be an instance of Time" \
-          unless timestamp.is_a?(Time)
-        raise ArgumentError, "signature should be a string" \
-          unless signature.is_a?(String)
-        raise ArgumentError, "scheme should be a string" \
-          unless scheme.is_a?(String)
-
-        "t=#{timestamp.to_i},#{scheme}=#{signature}"
+      if signatures.empty?
+        raise SignatureVerificationError.new(
+          message: "No signatures found with expected scheme #{EXPECTED_SCHEME}",
+          header: header, param: payload
+        )
       end
 
-      # Extracts the timestamp and the signature(s) with the desired scheme
-      # from the header
-      private def self.get_timestamp_and_signatures(header, scheme)
-        list_items = header.split(/,\s*/).map { |i| i.split("=", 2) }
-        timestamp = (list_items.select { |i| i[0] == "t" }[0][1]).to_i
-        signatures = list_items.select { |i| i[0] == scheme }.map { |i| i[1] }
-        [Time.at(timestamp), signatures]
+      expected_sig = compute_signature(timestamp: timestamp, payload: payload, secret: secret)
+      unless signatures.any? { |s| Crypto::Subtle.constant_time_compare(expected_sig, s) }
+        raise SignatureVerificationError.new(
+          "No signatures found matching the expected signature for payload" + [expected_sig, signatures].to_s,
+          header: header, param: payload
+        )
       end
 
-      # Verifies the signature header for a given payload.
-      #
-      # Raises a SignatureVerificationError in the following cases:
-      # - the header does not match the expected format
-      # - no signatures found with the expected scheme
-      # - no signatures matching the expected signature
-      # - a tolerance is provided and the timestamp is not within the
-      #   tolerance
-      #
-      # Returns true otherwise
-      def self.verify_header(payload, header, secret, tolerance = nil)
-        begin
-          timestamp, signatures =
-            get_timestamp_and_signatures(header, EXPECTED_SCHEME)
-
-        # TODO: Try to knock over this blanket rescue as it can unintentionally
-        # swallow many valid errors. Instead, try to validate an incoming
-        # header one piece at a time, and error with a known exception class if
-        # any part is found to be invalid. Rescue that class here.
-        rescue StandardError
-          raise SignatureVerificationError.new(
-            "Unable to extract timestamp and signatures from header",
-            header, http_body: payload
-          )
-        end
-
-        if signatures.empty?
-          raise SignatureVerificationError.new(
-            "No signatures found with expected scheme #{EXPECTED_SCHEME}",
-            header, http_body: payload
-          )
-        end
-
-        expected_sig = compute_signature(timestamp, payload, secret)
-        unless signatures.any? { |s| Util.secure_compare(expected_sig, s) }
-          raise SignatureVerificationError.new(
-            "No signatures found matching the expected signature for payload",
-            header, http_body: payload
-          )
-        end
-
-        if tolerance && timestamp < Time.now - tolerance
-          raise SignatureVerificationError.new(
-            "Timestamp outside the tolerance zone (#{Time.at(timestamp)})",
-            header, http_body: payload
-          )
-        end
-
-        true
+      if timestamp.to_unix.to_i < Time.utc.to_unix.to_i - tolerance
+        raise SignatureVerificationError.new(
+          "Timestamp outside the tolerance zone (#{timestamp})",
+          header: header, param: payload
+        )
       end
+
+      true
     end
   end
+end
+
+class SignatureVerificationError < Exception
+  include JSON::Serializable
+  property message : String?
+  property param : String?
+  property header : String?
+
+  def initialize(@message, @param, @header)
+  end
+end

--- a/src/stripe/objects/core/balance.cr
+++ b/src/stripe/objects/core/balance.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/balance/balance_object
+@[EventPayload]
 class Stripe::Balance
   include JSON::Serializable
 

--- a/src/stripe/objects/core/charge.cr
+++ b/src/stripe/objects/core/charge.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/charges/object
+@[EventPayload]
 class Stripe::Charge
   include JSON::Serializable
 

--- a/src/stripe/objects/core/coupon.cr
+++ b/src/stripe/objects/core/coupon.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/coupons/object
+@[EventPayload]
 class Stripe::Coupon
   include JSON::Serializable
 

--- a/src/stripe/objects/core/discount.cr
+++ b/src/stripe/objects/core/discount.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/discounts/object
+@[EventPayload]
 class Stripe::Discount
   include JSON::Serializable
 

--- a/src/stripe/objects/core/event.cr
+++ b/src/stripe/objects/core/event.cr
@@ -40,26 +40,25 @@ class Stripe::Event
   getter type : String
 end
 
-module Stripe::EventPayloadObjectConverter
-  STRIPE_OBJECT_TYPES = [
-    "customer",
-    "product",
-    "invoice",
-    "subscription",
-    "price",
-    "coupon",
-    "plan",
-    "balance",
-    "charge",
-    "payout",
-    "payment_intent",
-    "setup_intent",
-    "promotion_code",
-    "source",
-    "tax_rate",
-  ]
+STRIPE_OBJECT_TYPES = [
+  "customer",
+  "product",
+  "invoice",
+  "subscription",
+  "price",
+  "coupon",
+  "plan",
+  "balance",
+  "charge",
+  "payout",
+  "payment_intent",
+  "setup_intent",
+  "promotion_code",
+  "source",
+  "tax_rate",
+]
 
-  macro stripe_object_mapping
+macro stripe_object_mapping
        {% begin %}
       {
         {% for item in STRIPE_OBJECT_TYPES %}
@@ -69,10 +68,7 @@ module Stripe::EventPayloadObjectConverter
  {% end %}
   end
 
-  def stripe_object_type_discriminator(identifier : String)
-    stripe_object_mapping[identifier]
-  end
-
+module Stripe::EventPayloadObjectConverter
   def self.from_json(value : JSON::PullParser)
     object_json = value.read_raw
     object_identifier = JSON.parse(object_json)["object"].to_s

--- a/src/stripe/objects/core/event.cr
+++ b/src/stripe/objects/core/event.cr
@@ -8,8 +8,11 @@ class Stripe::Event
     getter idempotency_key : String?
   end
 
-  alias StripeObject = Stripe::Product | Stripe::Invoice | Stripe::Subscription | Stripe::Price | Stripe::Coupon | Stripe::Plan
+  alias StripeObject = Stripe::Customer | Stripe::Product | Stripe::Invoice | Stripe::Subscription | Stripe::Price | Stripe::Coupon | Stripe::Plan | Stripe::Balance | Stripe::Charge | Stripe::Payout | Stripe::PaymentIntent | Stripe::SetupIntent | Stripe::PromotionCode | Stripe::Source | Stripe::TaxRate # | Stripe::Checkout::Session
 
+  # missing Stripe objects to add : Stripe::Person | Stripe::File | Stripe::CreditNote | Stripe::Account | Stripe::Capability | Stripe::Identity | Stripe::InvoiceItem
+  # all Stripe::Issuing objects | Stripe::Mandate | Stripe::Order | Stripe::OrderReturn | Stripe::Radar | Stripe::Recipient | Stripe::Reporting | Stripe::Review | Stripe::Sigma |
+  # Stripe::Sku | Stripe::SubscriptionSchedule | Stripe::Topup | Stripe::Transfer |
   class Data
     include JSON::Serializable
     getter object : StripeObject
@@ -18,7 +21,7 @@ class Stripe::Event
   getter id : String
   getter api_version : String
   getter data : Data
-  getter request : Request
+  getter request : Request?
   getter object : String = "event"
   getter account : String?
 

--- a/src/stripe/objects/core/event.cr
+++ b/src/stripe/objects/core/event.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/events/object
+
 class Stripe::Event
   include JSON::Serializable
 
@@ -8,18 +9,12 @@ class Stripe::Event
     getter idempotency_key : String?
   end
 
-  alias StripeObject = Stripe::Customer | Stripe::Product | Stripe::Invoice | Stripe::Subscription | Stripe::Price | Stripe::Coupon | Stripe::Plan | Stripe::Balance | Stripe::Charge | Stripe::Payout | Stripe::PaymentIntent | Stripe::SetupIntent | Stripe::PromotionCode | Stripe::Source | Stripe::TaxRate # | Stripe::Checkout::Session
-
-  # missing Stripe objects to add : Stripe::Person | Stripe::File | Stripe::CreditNote | Stripe::Account | Stripe::Capability | Stripe::Identity | Stripe::InvoiceItem
-  # all Stripe::Issuing objects | Stripe::Mandate | Stripe::Order | Stripe::OrderReturn | Stripe::Radar | Stripe::Recipient | Stripe::Reporting | Stripe::Review | Stripe::Sigma |
-  # Stripe::Sku | Stripe::SubscriptionSchedule | Stripe::Topup | Stripe::Transfer |
   class Data
     include JSON::Serializable
 
     @[JSON::Field(converter: Stripe::EventPayloadObjectConverter)]
-    getter object : StripeObject
+    getter object : Payload
 
-    # @[JSON::Field(ignore)]
     getter previous_attributes : JSON::Any?
   end
 
@@ -39,34 +34,6 @@ class Stripe::Event
 
   getter type : String
 end
-
-STRIPE_OBJECT_TYPES = [
-  "customer",
-  "product",
-  "invoice",
-  "subscription",
-  "price",
-  "coupon",
-  "plan",
-  "balance",
-  "charge",
-  "payout",
-  "payment_intent",
-  "setup_intent",
-  "promotion_code",
-  "source",
-  "tax_rate",
-]
-
-macro stripe_object_mapping
-       {% begin %}
-      {
-        {% for item in STRIPE_OBJECT_TYPES %}
-    {{item.id}}: {{"Stripe::#{item.camelcase.id}".id}},
-  {% end %}
-      }
- {% end %}
-  end
 
 module Stripe::EventPayloadObjectConverter
   def self.from_json(value : JSON::PullParser)

--- a/src/stripe/objects/core/event.cr
+++ b/src/stripe/objects/core/event.cr
@@ -1,0 +1,33 @@
+# https://stripe.com/docs/api/events/object
+class Stripe::Event
+  include JSON::Serializable
+
+  class Request
+    include JSON::Serializable
+    getter id : String
+    getter idempotency_key : String?
+  end
+
+  alias StripeObject = Stripe::Product | Stripe::Invoice | Stripe::Subscription | Stripe::Price | Stripe::Coupon | Stripe::Plan
+
+  class Data
+    include JSON::Serializable
+    getter object : StripeObject
+  end
+
+  getter id : String
+  getter api_version : String
+  getter data : Data
+  getter request : Request
+  getter object : String = "event"
+  getter account : String?
+
+  @[JSON::Field(converter: Time::EpochConverter)]
+  getter created : Time?
+
+  getter livemode : Bool?
+
+  getter pending_webhooks : Int32
+
+  getter type : String
+end

--- a/src/stripe/objects/core/event.cr
+++ b/src/stripe/objects/core/event.cr
@@ -19,7 +19,7 @@ class Stripe::Event
     @[JSON::Field(converter: Stripe::EventPayloadObjectConverter)]
     getter object : StripeObject
 
-    @[JSON::Field(ignore)]
+    # @[JSON::Field(ignore)]
     getter previous_attributes : JSON::Any?
   end
 

--- a/src/stripe/objects/core/invoice.cr
+++ b/src/stripe/objects/core/invoice.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::Invoice
   include JSON::Serializable
 

--- a/src/stripe/objects/core/payment_intent.cr
+++ b/src/stripe/objects/core/payment_intent.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::PaymentIntent
   include JSON::Serializable
 

--- a/src/stripe/objects/core/payout.cr
+++ b/src/stripe/objects/core/payout.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/payouts/object
+@[EventPayload]
 class Stripe::Payout
   include JSON::Serializable
 

--- a/src/stripe/objects/core/plan.cr
+++ b/src/stripe/objects/core/plan.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::Plan
   include JSON::Serializable
 

--- a/src/stripe/objects/core/price.cr
+++ b/src/stripe/objects/core/price.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::Price
   include JSON::Serializable
 

--- a/src/stripe/objects/core/product.cr
+++ b/src/stripe/objects/core/product.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::Product
   include JSON::Serializable
 

--- a/src/stripe/objects/core/promotion_code.cr
+++ b/src/stripe/objects/core/promotion_code.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/promotion_codes/object
+@[EventPayload]
 class Stripe::PromotionCode
   include JSON::Serializable
 

--- a/src/stripe/objects/core/refund.cr
+++ b/src/stripe/objects/core/refund.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::Refund
   include JSON::Serializable
 

--- a/src/stripe/objects/core/setup_intent.cr
+++ b/src/stripe/objects/core/setup_intent.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::SetupIntent
   include JSON::Serializable
 

--- a/src/stripe/objects/core/source.cr
+++ b/src/stripe/objects/core/source.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::Source
   include JSON::Serializable
 

--- a/src/stripe/objects/core/subscription.cr
+++ b/src/stripe/objects/core/subscription.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/subscriptions/object
+@[EventPayload]
 class Stripe::Subscription
   include JSON::Serializable
 

--- a/src/stripe/objects/core/tax_rate.cr
+++ b/src/stripe/objects/core/tax_rate.cr
@@ -1,3 +1,4 @@
+@[EventPayload]
 class Stripe::TaxRate
   include JSON::Serializable
 


### PR DESCRIPTION
Stripe::Webhook utilities along the Stripe::Event Class. I've tested them live with success.

Crystal Nightly (but not Crystal 1.0.0) format tool triggers on event.cr . It doesn't output what needs to be changed.

Notes :
- I had to add a new `Exception` (`SignatureVerificationError`), because I couldn't extend the existing `Stripe::Error` which assumes the error must come from a json `Http::Response#body`
- The `Stripe::Event` has a `object` property which contains a Stripe::XXX object. I used an `Alias` oneliner which is a union of implemented Stripe objects. There might be a macro magic which could take care of that but my brain power is not up to the task yet.