### PR TITLE
Corrected create payment intent method

### DIFF
--- a/src/stripe/methods/core/payment_intents/create_payment_intent.cr
+++ b/src/stripe/methods/core/payment_intents/create_payment_intent.cr
@@ -13,11 +13,15 @@ class Stripe::PaymentIntent
     payment_method_types : Array(String)? = nil,
     receipt_email : String? = nil,
     setup_future_usage : String? = nil,
+    transfer_group : String? = nil,
+    capture_method : String? = nil,
     expand : Array(String)? = nil
   ) : PaymentIntent forall T, U
     customer = customer.as(Customer).id if customer.is_a?(Customer)
 
     case payment_method
+    when String
+      payment_method
     when Token, PaymentMethods::Card, PaymentMethods::BankAccount
       payment_method = payment_method.not_nil!.id
     when Nil
@@ -27,7 +31,7 @@ class Stripe::PaymentIntent
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(amount currency customer description metadata usage on_behalf_of payment_method_types payment_method receipt_email setup_future_usage return_url expand) %}
+    {% for x in %w(amount confirm currency customer description metadata usage on_behalf_of payment_method_types payment_method receipt_email setup_future_usage return_url transfer_group capture_method expand) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 


### PR DESCRIPTION
Added:
- transfer_group
- capture_method

For following the spec more correctly.

Also added missing confirm to the builder.