### PR TITLE
Removes quantity getter in Stripe::Subscription

### DIFF
--- a/src/stripe/objects/core/subscription.cr
+++ b/src/stripe/objects/core/subscription.cr
@@ -63,7 +63,6 @@ class Stripe::Subscription
   getter livemode : Bool?
   getter latest_invoice : String? | Stripe::Invoice?
   getter pending_setup_intent : String? | Stripe::SetupIntent?
-  getter quantity : Int32
   getter schedule : String?
 
   getter plan : Stripe::Plan?


### PR DESCRIPTION
While trying to pull and create a `Stripe::Subscription` from json payload, I got a parsing error :
```bash
Missing JSON attribute: quantity\n  parsing Stripe::Subscription at line 1, column 1
``` 
The json is correct wrt https://stripe.com/docs/api/subscriptions/object , the Stripe::Subscription object has only a quantity key buried in the item sub object.