### PR TITLE
Fixes Stripe::Name::Subname type event payloads and adds missing payload annotations

### DIFF
--- a/spec/stripe/methods/webhook_spec.cr
+++ b/spec/stripe/methods/webhook_spec.cr
@@ -19,6 +19,24 @@ describe Stripe::Webhook do
 
     {event.type, event.data.object.is_a?(Stripe::Product), event.data.previous_attributes}.should eq({"product.updated", true, {"metadata" => {"tier" => nil}, "updated" => 1620930329}})
   end
+  it "construct_event for a checkout session" do
+    timestamp = Time.utc
+    payload = File.read("spec/support/event_checkout_session.json")
+    secret = "secret"
+    signature = Stripe::Webhook::Signature.compute_signature(
+      timestamp,
+      payload,
+      secret
+    )
+    header = Stripe::Webhook::Signature.generate_header(
+      timestamp,
+      signature,
+      scheme: "v1"
+    )
+    event = Stripe::Webhook.construct_event(payload, header, secret)
+
+    {event.type, event.data.object.is_a?(Stripe::Checkout::Session), event.request.not_nil!.id}.should eq({"checkout.session.completed", true, "req_cILsoLL5w184zR"})
+  end
   it "Raises on wrong secret" do
     timestamp = Time.utc
     payload = File.read("spec/support/event.json")

--- a/spec/support/event_checkout_session.json
+++ b/spec/support/event_checkout_session.json
@@ -1,0 +1,59 @@
+{
+  "id": "evt_1JI9XrIShMssj1NZBYViMOrJ",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1627466362,
+  "data": {
+    "object": {
+      "id": "cs_test_a1CRnkRd9bgUN5UGxrPNxt2lAd9TYZAeA66k0BXrwm4clxo9C4RpunJJWn",
+      "object": "checkout.session",
+      "allow_promotion_codes": null,
+      "amount_subtotal": 500,
+      "amount_total": 500,
+      "automatic_tax": {
+        "enabled": false,
+        "status": null
+      },
+      "billing_address_collection": null,
+      "cancel_url": "https://server.bonk.com/pay-subscription-cancel",
+      "client_reference_id": null,
+      "currency": "usd",
+      "customer": "cus_JuBmL8HkpSaHuE",
+      "customer_details": {
+        "email": "honk@bonk.com",
+        "tax_exempt": "none",
+        "tax_ids": []
+      },
+      "customer_email": null,
+      "livemode": false,
+      "locale": null,
+      "metadata": {},
+      "mode": "subscription",
+      "payment_intent": null,
+      "payment_method_options": {},
+      "payment_method_types": [
+        "card"
+      ],
+      "payment_status": "paid",
+      "setup_intent": null,
+      "shipping": null,
+      "shipping_address_collection": null,
+      "submit_type": null,
+      "subscription": "sub_Jw1bkVOkXItiJG",
+      "success_url": "https://server.bonk.com/pay-subscription-success",
+      "total_details": {
+        "amount_discount": 0,
+        "amount_shipping": 0,
+        "amount_tax": 0
+      },
+      "url": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 3,
+  "request": {
+    "id": "req_cILsoLL5w184zR",
+    "idempotency_key": null
+  },
+  "type": "checkout.session.completed"
+}

--- a/src/stripe.cr
+++ b/src/stripe.cr
@@ -69,7 +69,7 @@ macro stripe_object_mapping
   {% begin %}
           {
         {% for item in Object.all_subclasses.select(&.annotation(EventPayload)) %}
-    {{"#{item.id.gsub(/Stripe::/, "").underscore.id}".id}}: {{item.id}},
+    {{"#{item.id.gsub(/Stripe::/, "").underscore.gsub(/::/, ".").id}"}} => {{item.id}},
   {% end %}
       }
 {% end %}

--- a/src/stripe/objects/account.cr
+++ b/src/stripe/objects/account.cr
@@ -1,4 +1,6 @@
 # https://stripe.com/docs/api/accounts/object
+
+@[EventPayload]
 class Stripe::Account
   include JSON::Serializable
 

--- a/src/stripe/objects/core/billing_portal/session.cr
+++ b/src/stripe/objects/core/billing_portal/session.cr
@@ -1,4 +1,5 @@
 # https://stripe.com/docs/api/customer_portal
+
 class Stripe::BillingPortal::Session
   include JSON::Serializable
 

--- a/src/stripe/objects/core/checkout/session.cr
+++ b/src/stripe/objects/core/checkout/session.cr
@@ -1,4 +1,6 @@
 # https://stripe.com/docs/api/checkout/sessions/object
+
+@[EventPayload]
 class Stripe::Checkout::Session
   include JSON::Serializable
 

--- a/src/stripe/objects/core/customer/customer.cr
+++ b/src/stripe/objects/core/customer/customer.cr
@@ -1,4 +1,6 @@
 # https://stripe.com/docs/api/customers/object
+
+@[EventPayload]
 class Stripe::Customer
   include JSON::Serializable
 

--- a/src/stripe/objects/core/file.cr
+++ b/src/stripe/objects/core/file.cr
@@ -1,5 +1,6 @@
 # https://stripe.com/docs/api/files/object
 
+@[EventPayload]
 class Stripe::File
   include JSON::Serializable
 


### PR DESCRIPTION
Fixes #35 

This PR :
- Makes the mapping macro work with `Stripe::Name::Subname` objects
- Makes the mapping macro outputs a Hash instead of a named tuple (tuple keys can't contain ".", but `event.data.object` identifier can contain (ie "checkout.session")
-  Adds missing `@[EventPayload]` annotations