### PR TITLE
Support Crystal v1.1.1 explicitly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - 0.36.1
           - 1.0.0
           - 1.1.1
+          - latest
         experimental: [false]
         include:
           - crystal_version: nightly
@@ -36,6 +37,7 @@ jobs:
 
       - name: Check format
         run: crystal tool format --check
+        if: matrix.crystal_version == 'latest'
 
       - name: Set up Crystal cache
         uses: actions/cache@v2.1.6
@@ -55,6 +57,7 @@ jobs:
 
       - name: Crystal Ameba Linter
         run: ./bin/ameba
+        if: matrix.crystal_version == 'latest'
 
       - name: Run tests
         run: crystal spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         crystal_version:
           - 0.36.1
           - 1.0.0
+          - 1.1.1
         experimental: [false]
         include:
           - crystal_version: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
 
     steps:
       - uses: actions/checkout@v2.3.4
+
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal_version }}
 
       - name: Check format
         run: crystal tool format --check


### PR DESCRIPTION
Made a few updates in this PR:

- Added support for Crystal 1.1.1
- Switched from running in Docker containers to using the [Install Crystal action](https://github.com/marketplace/actions/install-crystal)
- Only run `crystal tool format` and `./bin/ameba` on the `latest` version, since that's where we care about formatting and linting