### PR TITLE
Update event.cr to make request.id nilable.

### DIFF
--- a/src/stripe/objects/core/event.cr
+++ b/src/stripe/objects/core/event.cr
@@ -5,7 +5,7 @@ class Stripe::Event
 
   class Request
     include JSON::Serializable
-    getter id : String
+    getter id : String?
     getter idempotency_key : String?
   end
 


### PR DESCRIPTION
Stripe events are not always the same. "invoice.payment_succeeded" has an `event.request.id` of `nil` when it occurs at the end of a "invoice.payment_action_required" workflow. When it occurs otherwise it has an id.

Here's an example of an event.request sub-object:
```
"request" =>
{"id" => nil,
"idempotency_key" =>
"pi_3JLU8MIShNssj1NZ0IGhw32s-src_1JLQ8NIShMssj1YZhNZBDpLE"},
```
