### PR TITLE
Allow `promotion_code` in `promotion_code` when creating a checkout session.

### DIFF
--- a/src/stripe/methods/core/checkout/sessions/create_session.cr
+++ b/src/stripe/methods/core/checkout/sessions/create_session.cr
@@ -13,7 +13,7 @@ class Stripe::Checkout::Session
     subscription_data : NamedTuple(metadata: Hash(String, String)?)? = nil,
     allow_promotion_codes : Bool? = nil,
     metadata : Hash(String, String)? = nil,
-    discounts : Array(NamedTuple(coupon: String))? = nil
+    discounts : Array(NamedTuple(coupon: String) | NamedTuple(promotion_code: String))? = nil
   ) : Stripe::Checkout::Session
     customer = customer.not_nil!.id if customer.is_a?(Customer)
 


### PR DESCRIPTION
The checkout session supports `promotion_code` for the discount https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-discounts this PR adds it to the create method.

I'll be working with promotion codes, so there might be more PRs coming.