### PR TITLE
Update Customer param account_balance to balance

### DIFF
--- a/src/stripe/methods/core/customers/update_customer.cr
+++ b/src/stripe/methods/core/customers/update_customer.cr
@@ -1,7 +1,7 @@
 class Stripe::Customer
   def self.update(
     customer : String | Customer,
-    account_balance : Int32 | Unset = Unset.new,
+    balance : Int32 | Unset = Unset.new,
     coupon : String? | Unset = Unset.new,
     default_source : String | Token | Unset = Unset.new,
     name : String | Token? | Unset = Unset.new,
@@ -22,7 +22,7 @@ class Stripe::Customer
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(account_balance coupon default_source name description email phone invoice_prefix invoice_settings metadata shipping source tax_info) %}
+    {% for x in %w(balance coupon default_source name description email phone invoice_prefix invoice_settings metadata shipping source tax_info) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.is_a?(Unset)
     {% end %}
 


### PR DESCRIPTION
Passing `account_balance` to `Stripe::Customer.update` returns the following error: `Received unknown parameter: account_balance (Stripe: :Error)` in `lucky exec`. 

I've tested the `update` method using irb and it gave the same error when `account_balance` is used, but after changing it to `balance`, the code worked and the test customer credit balance on the Stripe dashboard was updated accordingly. 

<img width="586" alt="Screen Shot 2022-09-26 at 3 32 10 PM" src="https://user-images.githubusercontent.com/75438634/192224262-3b7653dc-89dc-4c32-b452-06a21e9d0d18.png">
<img width="819" alt="Screen Shot 2022-09-26 at 3 32 51 PM" src="https://user-images.githubusercontent.com/75438634/192224270-e0e1d50c-15b3-4937-8393-f968b54fbf1c.png">

<img width="850" alt="Screen Shot 2022-09-26 at 3 33 08 PM" src="https://user-images.githubusercontent.com/75438634/192224317-62ceafa7-e01b-4c49-80b4-bc37ef1d617b.png">
<img width="451" alt="Screen Shot 2022-09-26 at 3 33 54 PM" src="https://user-images.githubusercontent.com/75438634/192224491-f3a47665-c524-44b8-a069-e3f26535e284.png">
