### PR TITLE
Add payment_intent_data to create CheckoutSession

### DIFF
--- a/spec/support/create_checkout_session.json
+++ b/spec/support/create_checkout_session.json
@@ -31,5 +31,8 @@
       "price": "price_H5ggYwtDq4fbrJ",
       "quantity": 2
     }
-  ]
+  ],
+  "payment_intent_data": {
+    "receipt_email": "example@yahoo.com"
+  }
 }

--- a/src/stripe/methods/core/checkout/sessions/create_session.cr
+++ b/src/stripe/methods/core/checkout/sessions/create_session.cr
@@ -13,14 +13,15 @@ class Stripe::Checkout::Session
     subscription_data : NamedTuple(metadata: Hash(String, String)?)? = nil,
     allow_promotion_codes : Bool? = nil,
     metadata : Hash(String, String)? = nil,
-    discounts : Array(NamedTuple(coupon: String) | NamedTuple(promotion_code: String))? = nil
+    discounts : Array(NamedTuple(coupon: String) | NamedTuple(promotion_code: String))? = nil,
+    payment_intent_data : Hash(String, String)? = nil
   ) : Stripe::Checkout::Session
     customer = customer.not_nil!.id if customer.is_a?(Customer)
 
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(mode payment_method_types cancel_url success_url client_reference_id customer customer_email line_items expand subscription_data allow_promotion_codes metadata discounts) %}
+    {% for x in %w(mode payment_method_types cancel_url success_url client_reference_id customer customer_email line_items expand subscription_data allow_promotion_codes metadata discounts payment_intent_data) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 

--- a/src/stripe/objects/core/checkout/session.cr
+++ b/src/stripe/objects/core/checkout/session.cr
@@ -55,6 +55,7 @@ class Stripe::Checkout::Session
   getter line_items : Array(Hash(String, String | Int32))?
 
   getter metadata : Hash(String, String)?
+  getter payment_intent_data : Hash(String, String)?
 
   getter payment_intent : String? | Stripe::PaymentIntent?
   @[JSON::Field(converter: Enum::StringConverter(Stripe::Checkout::Session::PaymentStatus))]


### PR DESCRIPTION
Added `payment_intent_data` as one of the parameters for `Stripe::Checkout::Session.create` to be able to configure sending of payment receipts. 