### PR TITLE
Fix list method to work with params

### DIFF
--- a/spec/stripe/methods/price_spec.cr
+++ b/spec/stripe/methods/price_spec.cr
@@ -8,4 +8,13 @@ describe Stripe::Price do
     prices = Stripe::Price.list
     prices.first.id.should eq("price_1IqjDxJN5FrkuvKhKExUK1B2")
   end
+
+  it "listing prices with params" do
+    WebMock.stub(:get, "https://api.stripe.com/v1/prices")
+      .with(body: "currency=AUD")
+      .to_return(status: 200, body: File.read("spec/support/list_prices.json"), headers: {"Content-Type" => "application/json"})
+
+    prices = Stripe::Price.list(currency: "AUD")
+    prices.first.id.should eq("price_1IqjDxJN5FrkuvKhKExUK1B2")
+  end
 end

--- a/src/stripe/methods/list.cr
+++ b/src/stripe/methods/list.cr
@@ -8,7 +8,7 @@ module StripeMethods
   builder = ParamsBuilder.new(io)
 
   {% for x in arguments.map &.var.id %}
-    builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
+    builder.add({{x.stringify}}, {{x.id}}) unless {{x.id}}.nil?
   {% end %}
 
   response = Stripe.client.get("/v1/#{"{{@type.id.gsub(/Stripe::/, "").underscore.gsub(/::/, "/")}}"}s", form: io.to_s)


### PR DESCRIPTION
Thanks to @wezm to find this issue in #56.

The macro method to setup the builder with params was broken for list methods. This PR fix t hat issue.

This closes #56 