### PR TITLE
Change supported Crystal versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 0.36.1
-          - 1.0.0
           - 1.5.0
           - latest
         experimental: [false]

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ authors:
   - Vlad Faust <mail@vladfaust.com>
   - Håkan Nylén <hakan@dun.se>
 
-crystal: ">= 0.36.1, < 2.0.0"
+crystal: ">= 1.5.0"
 
 development_dependencies:
   webmock:
@@ -16,4 +16,4 @@ development_dependencies:
     branch: master
   ameba:
     github: crystal-ameba/ameba
-    branch: master
+    version: 1.1


### PR DESCRIPTION
As Crystal are at 1.6.2 and 1.7 will be released soon. I plan to change supported versions of crystal to be `>= 1.5.0` (higher or equal to 1.5.0).

This will be part of version 1.6 of Stripe.cr