### PR TITLE
Adding Stripe::PaymentMethods::BankAccount::Pending

### DIFF
--- a/src/stripe/objects/payment_methods/bank_account.cr
+++ b/src/stripe/objects/payment_methods/bank_account.cr
@@ -11,6 +11,7 @@ class Stripe::PaymentMethods::BankAccount
     Validated
     Verified
     Verification_failed
+    Pending
     Errored
   end
 


### PR DESCRIPTION
Trying to pull a Customer object was erroring out for me due to this missing Stripe::PaymentMethods::BankAccount::Status enum value of Pending! Added it and I can parse this Customer again.