### PR TITLE
Add ACH / Bank Account payment method improvements 

### DIFF
--- a/spec/stripe/methods/payment_intent_spec.cr
+++ b/spec/stripe/methods/payment_intent_spec.cr
@@ -34,4 +34,13 @@ describe Stripe::PaymentIntent do
     intent.id.should eq("pi_1GSdxwIfhoELGSZwHJ9Kcws7")
     intent.status.should eq(Stripe::PaymentIntent::Status::Succeeded)
   end
+
+  it "verifies microdeposits with amounts" do
+    WebMock.stub(:post, "https://api.stripe.com/v1/payment_intents/pi_1EUnwX4XsdaddaBS0K7XUB5v/verify_microdeposits")
+      .with(body: "amounts%5B0%5D=32&amounts%5B1%5D=45")
+      .to_return(status: 200, body: File.read("spec/support/retrieve_payment_intent.json"), headers: {"Content-Type" => "application/json"})
+
+    intent = Stripe::PaymentIntent.verify_microdeposits("pi_1EUnwX4XsdaddaBS0K7XUB5v", amounts: [32, 45])
+    intent.id.should eq("pi_1EUnwX4XsdaddaBS0K7XUB5v")
+  end
 end

--- a/spec/stripe/methods/payment_method_spec.cr
+++ b/spec/stripe/methods/payment_method_spec.cr
@@ -7,6 +7,13 @@ describe Stripe::PaymentMethod do
 
     payment_method = Stripe::PaymentMethod.retrieve("asddad")
     payment_method.id.should eq("pm_1EUnwZ4XsdaddaBS77el70wJ")
+
+    card = payment_method.card.not_nil!
+    card.brand.should eq("visa")
+    card.last4.should eq("4242")
+    card.exp_month.should eq(8)
+    card.exp_year.should eq(2020)
+    card.fingerprint.should eq("J9eTvsiEPmoRkLBN")
   end
 
   it "attaches payment method" do

--- a/spec/stripe/methods/payment_method_spec.cr
+++ b/spec/stripe/methods/payment_method_spec.cr
@@ -16,4 +16,18 @@ describe Stripe::PaymentMethod do
     payment_method = Stripe::PaymentMethod.attach("pm_1EUnwZ4XsdaddaBS77el70wJ", "cus_4QHS5k9YC2TcST")
     payment_method.customer.should eq("cus_4QHS5k9YC2TcST")
   end
+
+  it "deserializes a us_bank_account payment method" do
+    WebMock.stub(:get, "https://api.stripe.com/v1/payment_methods/pm_1MqLiJLkdIwHu7ixUEgbFdYF")
+      .to_return(status: 200, body: File.read("spec/support/retrieve_us_bank_account_payment_method.json"), headers: {"Content-Type" => "application/json"})
+
+    payment_method = Stripe::PaymentMethod.retrieve("pm_1MqLiJLkdIwHu7ixUEgbFdYF")
+    payment_method.type.should eq("us_bank_account")
+    bank = payment_method.us_bank_account.not_nil!
+    bank.bank_name.should eq("STRIPE TEST BANK")
+    bank.last4.should eq("6789")
+    bank.routing_number.should eq("110000000")
+    bank.account_type.should eq("checking")
+    bank.account_holder_type.should eq("individual")
+  end
 end

--- a/spec/stripe/methods/setup_intent_spec.cr
+++ b/spec/stripe/methods/setup_intent_spec.cr
@@ -34,4 +34,36 @@ describe Stripe::SetupIntent do
     intent.id.should eq("seti_123456789")
     intent.status.should eq(Stripe::SetupIntent::Status::RequiresPaymentMethod)
   end
+
+  it "creates an ACH (us_bank_account) setup intent" do
+    WebMock.stub(:post, "https://api.stripe.com/v1/setup_intents")
+      .with(body: "payment_method_types%5B0%5D=us_bank_account&payment_method_options%5Bus_bank_account%5D%5Bverification_method%5D=automatic")
+      .to_return(status: 200, body: File.read("spec/support/create_setup_intent.json"), headers: {"Content-Type" => "application/json"})
+
+    intent = Stripe::SetupIntent.create(
+      payment_method_types: ["us_bank_account"],
+      payment_method_options: {us_bank_account: {verification_method: "automatic"}},
+    )
+
+    intent.id.should eq("seti_1GSdvVIfhoELGSZwebOwTZO1")
+  end
+
+  it "verifies microdeposits with amounts" do
+    WebMock.stub(:post, "https://api.stripe.com/v1/setup_intents/seti_123456789/verify_microdeposits")
+      .with(body: "amounts%5B0%5D=32&amounts%5B1%5D=45")
+      .to_return(status: 200, body: File.read("spec/support/verify_microdeposits_setup_intent.json"), headers: {"Content-Type" => "application/json"})
+
+    intent = Stripe::SetupIntent.verify_microdeposits("seti_123456789", amounts: [32, 45])
+    intent.id.should eq("seti_123456789")
+    intent.status.should eq(Stripe::SetupIntent::Status::Succeeded)
+  end
+
+  it "verifies microdeposits with a descriptor_code" do
+    WebMock.stub(:post, "https://api.stripe.com/v1/setup_intents/seti_123456789/verify_microdeposits")
+      .with(body: "descriptor_code=SM11AA")
+      .to_return(status: 200, body: File.read("spec/support/verify_microdeposits_setup_intent.json"), headers: {"Content-Type" => "application/json"})
+
+    intent = Stripe::SetupIntent.verify_microdeposits("seti_123456789", descriptor_code: "SM11AA")
+    intent.id.should eq("seti_123456789")
+  end
 end

--- a/spec/stripe/param_builder_spec.cr
+++ b/spec/stripe/param_builder_spec.cr
@@ -19,6 +19,15 @@ describe Stripe::ParamsBuilder do
     io.to_s.should eq("test%5B0%5D=string1&test%5B1%5D=string2")
   end
 
+  it "can handle int arrays" do
+    io = IO::Memory.new
+    builder = Stripe::ParamsBuilder.new(io)
+
+    builder.add("amounts", [32, 45])
+
+    io.to_s.should eq("amounts%5B0%5D=32&amounts%5B1%5D=45")
+  end
+
   it "can handle hash" do
     io = IO::Memory.new
     builder = Stripe::ParamsBuilder.new(io)

--- a/spec/support/retrieve_us_bank_account_payment_method.json
+++ b/spec/support/retrieve_us_bank_account_payment_method.json
@@ -1,0 +1,35 @@
+{
+  "id": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": "jenny@example.com",
+    "name": "Jenny Rosen",
+    "phone": null
+  },
+  "created": 1556599912,
+  "customer": "cus_4QHS5k9YC2TcST",
+  "livemode": false,
+  "metadata": {},
+  "type": "us_bank_account",
+  "us_bank_account": {
+    "account_holder_type": "individual",
+    "account_type": "checking",
+    "bank_name": "STRIPE TEST BANK",
+    "financial_connections_account": null,
+    "fingerprint": "LstWJFsHfwiuoslc",
+    "last4": "6789",
+    "networks": {
+      "preferred": "ach",
+      "supported": ["ach"]
+    },
+    "routing_number": "110000000"
+  }
+}

--- a/spec/support/verify_microdeposits_setup_intent.json
+++ b/spec/support/verify_microdeposits_setup_intent.json
@@ -1,0 +1,28 @@
+{
+  "id": "seti_123456789",
+  "object": "setup_intent",
+  "application": null,
+  "cancellation_reason": null,
+  "client_secret": null,
+  "created": 123456789,
+  "customer": null,
+  "description": null,
+  "last_setup_error": null,
+  "livemode": false,
+  "mandate": "mandate_123456789",
+  "metadata": {},
+  "next_action": null,
+  "on_behalf_of": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
+  "payment_method_options": {
+    "us_bank_account": {
+      "verification_method": "microdeposits"
+    }
+  },
+  "payment_method_types": [
+    "us_bank_account"
+  ],
+  "single_use_mandate": null,
+  "status": "succeeded",
+  "usage": "off_session"
+}

--- a/src/stripe/methods/core/charges/create_charge.cr
+++ b/src/stripe/methods/core/charges/create_charge.cr
@@ -14,7 +14,8 @@ class Stripe::Charge
     source : String | Token | PaymentMethods::Card | PaymentMethods::BankAccount? = nil,
     statement_descriptor : String? = nil,
     transfer_group : String? = nil,
-    expand : Array(String)? = nil
+    expand : Array(String)? = nil,
+    idempotency_key : String? = nil
   ) : Charge forall T, U
     customer = customer.as(Customer).id if customer.is_a?(Customer)
 
@@ -32,7 +33,10 @@ class Stripe::Charge
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 
-    response = Stripe.client.post("/v1/charges", form: io.to_s)
+    headers = HTTP::Headers.new
+    headers["Idempotency-Key"] = idempotency_key if idempotency_key
+
+    response = Stripe.client.post("/v1/charges", headers: headers, form: io.to_s)
 
     if response.status_code == 200
       Charge.from_json(response.body)

--- a/src/stripe/methods/core/payment_intents/confirm_payment_intent.cr
+++ b/src/stripe/methods/core/payment_intents/confirm_payment_intent.cr
@@ -3,7 +3,8 @@ class Stripe::PaymentIntent
     intent : String | PaymentIntent? = nil,
     payment_method : String | Token | PaymentMethods::Card | PaymentMethods::BankAccount? = nil,
     receipt_email : String? = nil,
-    return_url : String? = nil
+    return_url : String? = nil,
+    idempotency_key : String? = nil
   ) : PaymentIntent forall T, U
     intent = intent.as(PaymentIntent).id if intent.is_a?(PaymentIntent)
 
@@ -18,7 +19,10 @@ class Stripe::PaymentIntent
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 
-    response = Stripe.client.post("/v1/payment_intents/#{intent}/confirm", form: io.to_s)
+    headers = HTTP::Headers.new
+    headers["Idempotency-Key"] = idempotency_key if idempotency_key
+
+    response = Stripe.client.post("/v1/payment_intents/#{intent}/confirm", headers: headers, form: io.to_s)
 
     if response.status_code == 200
       PaymentIntent.from_json(response.body)

--- a/src/stripe/methods/core/payment_intents/create_payment_intent.cr
+++ b/src/stripe/methods/core/payment_intents/create_payment_intent.cr
@@ -16,7 +16,8 @@ class Stripe::PaymentIntent
     setup_future_usage : String? = nil,
     transfer_group : String? = nil,
     capture_method : String? = nil,
-    expand : Array(String)? = nil
+    expand : Array(String)? = nil,
+    idempotency_key : String? = nil
   ) : PaymentIntent forall T, U
     customer = customer.as(Customer).id if customer.is_a?(Customer)
 
@@ -36,7 +37,10 @@ class Stripe::PaymentIntent
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 
-    response = Stripe.client.post("/v1/payment_intents", form: io.to_s)
+    headers = HTTP::Headers.new
+    headers["Idempotency-Key"] = idempotency_key if idempotency_key
+
+    response = Stripe.client.post("/v1/payment_intents", headers: headers, form: io.to_s)
 
     if response.status_code == 200
       PaymentIntent.from_json(response.body)

--- a/src/stripe/methods/core/payment_intents/create_payment_intent.cr
+++ b/src/stripe/methods/core/payment_intents/create_payment_intent.cr
@@ -11,6 +11,7 @@ class Stripe::PaymentIntent
     payment_method : String | Token | PaymentMethods::Card | PaymentMethods::BankAccount? = nil,
     return_url : String? = nil,
     payment_method_types : Array(String)? = nil,
+    payment_method_options : NamedTuple | Hash? = nil,
     receipt_email : String? = nil,
     setup_future_usage : String? = nil,
     transfer_group : String? = nil,
@@ -31,7 +32,7 @@ class Stripe::PaymentIntent
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(amount confirm currency customer description metadata usage on_behalf_of payment_method_types payment_method receipt_email setup_future_usage return_url transfer_group capture_method expand) %}
+    {% for x in %w(amount confirm currency customer description metadata usage on_behalf_of payment_method_types payment_method_options payment_method receipt_email setup_future_usage return_url transfer_group capture_method expand) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 

--- a/src/stripe/methods/core/payment_intents/verify_microdeposits.cr
+++ b/src/stripe/methods/core/payment_intents/verify_microdeposits.cr
@@ -1,0 +1,26 @@
+class Stripe::PaymentIntent
+  # Verify a us_bank_account PaymentIntent via microdeposits.
+  # Provide EITHER `amounts` (two integer cent values) OR a `descriptor_code`.
+  def self.verify_microdeposits(
+    intent : String | PaymentIntent,
+    amounts : Array(Int32)? = nil,
+    descriptor_code : String? = nil
+  ) : PaymentIntent
+    intent = intent.as(PaymentIntent).id if intent.is_a?(PaymentIntent)
+
+    io = IO::Memory.new
+    builder = ParamsBuilder.new(io)
+
+    {% for x in %w(amounts descriptor_code) %}
+      builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
+    {% end %}
+
+    response = Stripe.client.post("/v1/payment_intents/#{intent}/verify_microdeposits", form: io.to_s)
+
+    if response.status_code == 200
+      PaymentIntent.from_json(response.body)
+    else
+      raise Error.from_json(response.body, "error")
+    end
+  end
+end

--- a/src/stripe/methods/core/refunds/create_refund.cr
+++ b/src/stripe/methods/core/refunds/create_refund.cr
@@ -4,7 +4,8 @@ class Stripe::Refund
     amount : Int32? = nil,
     metadata : Hash? = nil,
     payment_intent : String | Stripe::PaymentIntent? = nil,
-    reason : String? = nil
+    reason : String? = nil,
+    idempotency_key : String? = nil
   ) : Refund forall T, U
     if charge.is_a?(Stripe::Charge)
       charge = charge.id
@@ -21,7 +22,10 @@ class Stripe::Refund
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 
-    response = Stripe.client.post("/v1/refunds", form: io.to_s)
+    headers = HTTP::Headers.new
+    headers["Idempotency-Key"] = idempotency_key if idempotency_key
+
+    response = Stripe.client.post("/v1/refunds", headers: headers, form: io.to_s)
 
     if response.status_code == 200
       Refund.from_json(response.body)

--- a/src/stripe/methods/core/setup_intents/confirm_setup_intent.cr
+++ b/src/stripe/methods/core/setup_intents/confirm_setup_intent.cr
@@ -2,6 +2,7 @@ class Stripe::SetupIntent
   def self.confirm(
     intent : String | SetupIntent? = nil,
     payment_method : String | Token | PaymentMethods::Card | PaymentMethods::BankAccount? = nil,
+    payment_method_options : NamedTuple | Hash? = nil,
     return_url : String? = nil
   ) : SetupIntent forall T, U
     intent = intent.as(SetupIntent).id if intent.is_a?(SetupIntent)
@@ -13,7 +14,7 @@ class Stripe::SetupIntent
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(payment_method return_url) %}
+    {% for x in %w(payment_method payment_method_options return_url) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 

--- a/src/stripe/methods/core/setup_intents/create_setup_intent.cr
+++ b/src/stripe/methods/core/setup_intents/create_setup_intent.cr
@@ -6,6 +6,8 @@ class Stripe::SetupIntent
     on_behalf_of : String? = nil,
     usage : String? = nil,
     payment_method : String | Token | PaymentMethods::Card | PaymentMethods::BankAccount? = nil,
+    payment_method_types : Array(String)? = nil,
+    payment_method_options : NamedTuple | Hash? = nil,
     return_url : String? = nil,
     expand : Array(String)? = nil
   ) : SetupIntent forall T, U
@@ -21,7 +23,7 @@ class Stripe::SetupIntent
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(customer description metadata usage on_behalf_of payment_method return_url expand) %}
+    {% for x in %w(customer description metadata usage on_behalf_of payment_method payment_method_types payment_method_options return_url expand) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 

--- a/src/stripe/methods/core/setup_intents/verify_microdeposits.cr
+++ b/src/stripe/methods/core/setup_intents/verify_microdeposits.cr
@@ -1,0 +1,26 @@
+class Stripe::SetupIntent
+  # Verify a us_bank_account SetupIntent via microdeposits.
+  # Provide EITHER `amounts` (two integer cent values) OR a `descriptor_code`.
+  def self.verify_microdeposits(
+    intent : String | SetupIntent,
+    amounts : Array(Int32)? = nil,
+    descriptor_code : String? = nil
+  ) : SetupIntent
+    intent = intent.as(SetupIntent).id if intent.is_a?(SetupIntent)
+
+    io = IO::Memory.new
+    builder = ParamsBuilder.new(io)
+
+    {% for x in %w(amounts descriptor_code) %}
+      builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
+    {% end %}
+
+    response = Stripe.client.post("/v1/setup_intents/#{intent}/verify_microdeposits", form: io.to_s)
+
+    if response.status_code == 200
+      SetupIntent.from_json(response.body)
+    else
+      raise Error.from_json(response.body, "error")
+    end
+  end
+end

--- a/src/stripe/methods/core/subscriptions/create_subscription.cr
+++ b/src/stripe/methods/core/subscriptions/create_subscription.cr
@@ -9,6 +9,7 @@ class Stripe::Subscription
     items : U? = nil,
     add_invoice_items : U? = nil,
     trial_end : Time? = nil,
+    payment_settings : NamedTuple | Hash? = nil,
     expand : Array(String)? = nil
   ) : Subscription forall T, U
     if customer.is_a?(Customer)
@@ -27,7 +28,7 @@ class Stripe::Subscription
     io = IO::Memory.new
     builder = ParamsBuilder.new(io)
 
-    {% for x in %w(customer coupon default_source off_session metadata default_payment_method items add_invoice_items expand trial_end) %}
+    {% for x in %w(customer coupon default_source off_session metadata default_payment_method items add_invoice_items payment_settings expand trial_end) %}
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 

--- a/src/stripe/methods/core/subscriptions/create_subscription.cr
+++ b/src/stripe/methods/core/subscriptions/create_subscription.cr
@@ -10,7 +10,8 @@ class Stripe::Subscription
     add_invoice_items : U? = nil,
     trial_end : Time? = nil,
     payment_settings : NamedTuple | Hash? = nil,
-    expand : Array(String)? = nil
+    expand : Array(String)? = nil,
+    idempotency_key : String? = nil
   ) : Subscription forall T, U
     if customer.is_a?(Customer)
       customer = customer.id
@@ -32,7 +33,10 @@ class Stripe::Subscription
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 
-    response = Stripe.client.post("/v1/subscriptions", form: io.to_s)
+    headers = HTTP::Headers.new
+    headers["Idempotency-Key"] = idempotency_key if idempotency_key
+
+    response = Stripe.client.post("/v1/subscriptions", headers: headers, form: io.to_s)
 
     if response.status_code == 200
       Subscription.from_json(response.body)

--- a/src/stripe/methods/core/transfers/create_transfer.cr
+++ b/src/stripe/methods/core/transfers/create_transfer.cr
@@ -3,7 +3,8 @@ class Stripe::Transfer
     amount : Int32,
     destination : String | Stripe::Account,
     currency : String,
-    description : String? = nil
+    description : String? = nil,
+    idempotency_key : String? = nil
   ) : Transfer forall T, U
     destination = destination.id if destination.is_a?(Stripe::Account)
 
@@ -14,7 +15,10 @@ class Stripe::Transfer
       builder.add({{x}}, {{x.id}}) unless {{x.id}}.nil?
     {% end %}
 
-    response = Stripe.client.post("/v1/transfers", form: io.to_s)
+    headers = HTTP::Headers.new
+    headers["Idempotency-Key"] = idempotency_key if idempotency_key
+
+    response = Stripe.client.post("/v1/transfers", headers: headers, form: io.to_s)
 
     if response.status_code == 200
       Transfer.from_json(response.body)

--- a/src/stripe/objects/core/setup_intent.cr
+++ b/src/stripe/objects/core/setup_intent.cr
@@ -20,6 +20,24 @@ class Stripe::SetupIntent
     Succeeded
   end
 
+  # Set while the SetupIntent needs an extra step before it's usable. For ACH the
+  # case we care about is manual microdeposit verification, where Stripe exposes a
+  # hosted page the customer uses to enter the amounts/descriptor code.
+  class NextAction
+    include JSON::Serializable
+
+    class VerifyWithMicrodeposits
+      include JSON::Serializable
+
+      getter arrival_date : Int64?
+      getter hosted_verification_url : String?
+      getter microdeposit_type : String?
+    end
+
+    getter type : String?
+    getter verify_with_microdeposits : VerifyWithMicrodeposits?
+  end
+
   getter id : String
   getter application : String?
   getter cancellation_reason : String?
@@ -39,4 +57,13 @@ class Stripe::SetupIntent
   @[JSON::Field(converter: Enum::StringConverter(Stripe::SetupIntent::Status))]
   getter status : Status
   getter usage : String
+  getter next_action : NextAction?
+
+  # Stripe-hosted page where the customer enters microdeposit amounts / the
+  # descriptor code to verify an ACH bank account. Present only while the
+  # SetupIntent is awaiting manual microdeposit verification; nil otherwise
+  # (cards, instant-verified ACH, or still-processing instant verification).
+  def verify_with_microdeposits_url : String?
+    self.next_action.try(&.verify_with_microdeposits).try(&.hosted_verification_url)
+  end
 end

--- a/src/stripe/objects/payment_methods/payment_method.cr
+++ b/src/stripe/objects/payment_methods/payment_method.cr
@@ -13,6 +13,19 @@ class Stripe::PaymentMethod
     getter phone : String?
   end
 
+  # Modern us_bank_account (ACH direct-debit) PaymentMethod details.
+  # NOT the legacy Sources-shaped PaymentMethods::BankAccount object.
+  class UsBankAccount
+    include JSON::Serializable
+
+    getter account_holder_type : String? # "individual" | "company"
+    getter account_type : String?        # "checking" | "savings"
+    getter bank_name : String?
+    getter fingerprint : String?
+    getter last4 : String?
+    getter routing_number : String?
+  end
+
   getter id : String
 
   @[JSON::Field(converter: Time::EpochConverter)]
@@ -23,4 +36,7 @@ class Stripe::PaymentMethod
   getter? livemode : Bool
 
   getter billing_details : BillingDetails?
+
+  @[JSON::Field(key: "us_bank_account")]
+  getter us_bank_account : UsBankAccount?
 end

--- a/src/stripe/objects/payment_methods/payment_method.cr
+++ b/src/stripe/objects/payment_methods/payment_method.cr
@@ -13,6 +13,18 @@ class Stripe::PaymentMethod
     getter phone : String?
   end
 
+  # Card details as they appear nested on a PaymentMethod. NOT the legacy
+  # PaymentMethods::Card object — that one requires an `id` this sub-block lacks.
+  class Card
+    include JSON::Serializable
+
+    getter brand : String? # "visa" | "mastercard" | ...
+    getter last4 : String?
+    getter exp_month : UInt8?
+    getter exp_year : UInt16?
+    getter fingerprint : String?
+  end
+
   # Modern us_bank_account (ACH direct-debit) PaymentMethod details.
   # NOT the legacy Sources-shaped PaymentMethods::BankAccount object.
   class UsBankAccount
@@ -39,4 +51,6 @@ class Stripe::PaymentMethod
 
   @[JSON::Field(key: "us_bank_account")]
   getter us_bank_account : UsBankAccount?
+
+  getter card : Card?
 end

--- a/src/stripe/params_builder.cr
+++ b/src/stripe/params_builder.cr
@@ -7,6 +7,12 @@ class Stripe::ParamsBuilder < HTTP::Params::Builder
     end
   end
 
+  def add(key, value : Array(Int32 | Int64))
+    value.each_with_index do |v, i|
+      add("#{key}[#{i}]", v.to_s)
+    end
+  end
+
   def add(key, value : Array(Hash(K, V) | NamedTuple)) forall K, V
     value.each_with_index do |v, i|
       add("#{key}[#{i}]", v)


### PR DESCRIPTION
These are needed in order to manage bank account subscriptions... the microdeposit stuff is only required if the customer doesn't choose a bank from the list, but rather enters the routing and account number manually. Also adds support for idempotency keys for important (money moving) transactions.